### PR TITLE
Improve code and comments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 Gergely Szabo
+Copyright (c) 2024-2026 Gergely Szabo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Linux/KMonad/README.md
+++ b/Linux/KMonad/README.md
@@ -13,68 +13,28 @@
 
 — *README.md*, KMonad, [link](https://github.com/kmonad/kmonad)
 
-## Installation & Startup
+## Requirements
 
-### Linux
+- **KMonad 0.4.2+:** Ensure you have the latest version installed. The minimal required version is 0.4.2.
+- **Linux (Debian 12+, Ubuntu 22.04+, Fedora 42+ etc.):** The configuration file is tested on modern Linux distributions.
+- **Windows 10+:** I view KMonad as a “Linux first” solution; while running it on Windows is possible, make sure you download the Windows binary.
 
-> [!IMPORTANT]
-> **This repository does not package or distribute the KMonad binary required to run the Keeb Utils configuration file. It is your responsibility to install the required software version.**
+## Installation
 
-1. Install KMonad using:
-
-    - the latest [binary release](https://github.com/kmonad/kmonad/releases).
-    - a [compiliation method](https://github.com/kmonad/kmonad/blob/master/doc/installation.md#compilation).
-
-2. Clone the contents of this repository to your computer.
-
+1. **Download the scripts:** Clone or download this repository to your computer.
 ```shell
-git clone https://github.com/szageda/keeb-utils.git
+git clone https://github.com/szageda/keeb-utils
 ```
-3. Load `keeb-utils.kbd` with KMonad.
-
+2. **Launch KMonad:** Start KMonad with the configuration file.
 ```shell
 kmonad ~/Downloads/keeb-utils-main/Linux/KMonad/keeb-utils.kbd
 ```
-> [!WARNING]
-> **You must configure your input device before KMonad can load: Change the value of `input (device-file "value")` following the KMonad [instructions](https://github.com/kmonad/kmonad/blob/master/doc/faq.md#q-how-do-i-know-which-event-file-corresponds-to-my-keyboard).**
-
-> [!IMPORTANT]
-> If you haven't configured the uinput permissions for your user, you must run KMonad as sudo.
-
-> [!TIP]
-> Placing KMonad into your `$PATH` helps, so you don't have to type the absolute path to the executable every time you want to run it.
-
-> [!NOTE]
-> KMonad must be restarted (stopped and started) everytime you make changes to a configuration file.
-
-### Windows
-
-> [!NOTE]
-> KMonad is compatible with Windows, but I view it as a “Linux first” solution, so I only use Keeb Utils with KMonad on Windows when I need to conduct tests.
-
-> [!IMPORTANT]
-> **This repository does not package or distribute the KMonad binary required to run the Keeb Utils configuration file. It is your responsibility to install the required software version.**
-
-1. Install KMonad using:
-
-    - the latest [binary release](https://github.com/kmonad/kmonad/releases).
-    - the [Windows compiliation method](https://github.com/kmonad/kmonad/blob/master/doc/installation.md#windows-environment).
-
-2. Donwload the contents of this repository to your computer.
-
-3. Extract `keeb-utils-main.zip`.
-
-3. Load `keeb-utils.kbd` with KMonad using Windows Terminal, PowerShell, or CMD.
-
-```PowerShell
-kmonad C:\Users\%username%\Downloads\keeb-utils-main\Linux\KMonad\keeb-utils.kbd
-```
 
 > [!WARNING]
-> **You must configure your input method before KMonad can load: Comment (insert `;;`) the lines starting with `input` and `output` under the `Linux` section, then uncomment (remove `;;`) the lines starting with `input` and `output` under the `Windows` section.**
+> **You must configure your input device before KMonad can start: Change the value of `input (device-file "value")` following the KMonad [instructions](https://github.com/kmonad/kmonad/blob/master/doc/faq.md#q-how-do-i-know-which-event-file-corresponds-to-my-keyboard).**
 
-> [!TIP]
-> To quit KMonad, use the <kbd>Ctrl</kbd>+<kbd>X</kbd> combination inside the Windows Terminal, PowerShell, or CMD window.
+## Usage
 
-> [!NOTE]
-> KMonad must be restarted (stopped and started) everytime you make changes to a configuration file.
+To keep KMonad running in the background, use one of the following methods:
+- Run KMonad inside a [tmux](https://github.com/tmux/tmux) session.
+- Run KMonad as a [systemd service](https://github.com/kmonad/kmonad/blob/master/startup/kmonad%40.service).

--- a/Linux/KMonad/README.md
+++ b/Linux/KMonad/README.md
@@ -15,17 +15,17 @@
 
 ## Requirements
 
-- **KMonad 0.4.2+:** Ensure you have the latest version installed. The minimal required version is 0.4.2.
-- **Linux (Debian 12+, Ubuntu 22.04+, Fedora 42+ etc.):** The configuration file is tested on modern Linux distributions.
-- **Windows 10+:** I view KMonad as a “Linux first” solution; while running it on Windows is possible, make sure you download the Windows binary.
+- **KMonad 0.4.2+**: Ensure you have the latest version installed. The minimal required version is 0.4.2.
+- **Linux (Debian 12+, Ubuntu 22.04+, Fedora 42+ etc.)**: The configuration file is tested on modern Linux distributions.
+- **Windows 10+**: I view KMonad as a “Linux first” solution; while running it on Windows is possible, make sure you download the Windows binary.
 
 ## Installation
 
-1. **Download the scripts:** Clone or download this repository to your computer.
+1. **Download the scripts**: Clone or download this repository to your computer.
 ```shell
 git clone https://github.com/szageda/keeb-utils
 ```
-2. **Launch KMonad:** Start KMonad with the configuration file.
+2. **Launch KMonad**: Start KMonad with the configuration file.
 ```shell
 kmonad ~/Downloads/keeb-utils-main/Linux/KMonad/keeb-utils.kbd
 ```

--- a/Linux/KMonad/keeb-utils.kbd
+++ b/Linux/KMonad/keeb-utils.kbd
@@ -1,13 +1,13 @@
 #|
 File        : keeb-utils.kbd
 Description : KMonad keymap configuration file for Keeb Utils
-Copyright   : (c) 2024-2025, Gergely Szabo
+Copyright   : (c) 2024-2026, Gergely Szabo
 License     : MIT
 |#
 
-;;;
-;;;  KMONAD CONFIGURATION
-;;;
+;;
+;; KMonad General Configuration
+;;
 
 ;; The 'defcfg' block defines global configuration options of KMonad. This
 ;; includes the input and output devices, and customizing various behaviors.
@@ -37,9 +37,9 @@ License     : MIT
   allow-cmd false
 )
 
-;;;
-;;; KEYBOARD KEYMAPS
-;;;
+;;
+;; Keymaps
+;;
 
 ;; The 'defsrc' block defines the source keyboard layout -- this is the layout
 ;; of the host operating system. It's advised to keep it US QWERTY, unless you
@@ -160,9 +160,9 @@ License     : MIT
   lctl lmet lalt           spc            ralt cmp  rmet rctl
 )
 
-;;;
-;;; ALIASES
-;;;
+;;
+;; Aliases
+;;
 
 ;; The 'defalias' block defines aliases -- they are used to identify custom
 ;; keymaps, key combinations, and macros. Also, alias definitions can be used
@@ -191,9 +191,6 @@ License     : MIT
   udo C-z
 
   ;; Sticky Keys
-  ;;
-  ;; - On Tap: Sticky key with a timeout.
-  ;; - On Hold: Act as a regular modifier.
   ssk (sticky-key 450 lsft)
 
   ;; Multi-Sticky Keys
@@ -202,18 +199,6 @@ License     : MIT
   ;; (see: https://github.com/kmonad/kmonad/discussions/1013), 'multi-tap'
   ;; creates a single multi-tap sticky key that combines two modifiers. This
   ;; allows for Ctrl+Shift+S to work as expected.
-  ;;
-  ;;  - Single Tap & Release: Sticky the primary modifier for the next key
-  ;;                          press (stickiness expires after the timeout
-  ;;                          period).
-  ;;    - Single Tap & Hold: Hold the primary modifier.
-  ;;  - Double Tap & Release: Sticky two modifiers for the next key press
-  ;;                          (stickiness expires after the timeout period).
-  ;;    - Double Tap & Hold: Hold both modifiers.
-  ;;
-  ;; Notes:
-  ;;  - The tap counter resets after its defined timeout period.
-  ;;  - The sticky keys expire after their defined timeout period.
   ;;
   ;; Important: For this to work, you must compile KMomad from source with the
   ;; patch from https://github.com/kmonad/kmonad/pull/1014 (commit 21744cc).

--- a/Linux/KMonad/keeb-utils.kbd
+++ b/Linux/KMonad/keeb-utils.kbd
@@ -200,13 +200,20 @@ License     : MIT
   ;;
   ;; To fix the issue of Ctrl and Shift not combining with 'sticky-key'
   ;; (see: https://github.com/kmonad/kmonad/discussions/1013), 'multi-tap'
-  ;; is used to create a multi-tap sticky key that combines modifiers into a
-  ;; single key. This allows for Ctrl+Shift+S to work as expected.
+  ;; creates a single multi-tap sticky key that combines two modifiers. This
+  ;; allows for Ctrl+Shift+S to work as expected.
   ;;
-  ;; - Single Tap: Sticky the modifier for the next key press then release.
-  ;;  - Single Tap & Hold: Hold the modifier.
-  ;; - Double Tap: Sticky both modifiers for the next key press then release.
-  ;;  - Double Tap & Hold: Hold both modifiers.
+  ;;  - Single Tap & Release: Sticky the primary modifier for the next key
+  ;;                          press (stickiness expires after the timeout
+  ;;                          period).
+  ;;    - Single Tap & Hold: Hold the primary modifier.
+  ;;  - Double Tap & Release: Sticky two modifiers for the next key press
+  ;;                          (stickiness expires after the timeout period).
+  ;;    - Double Tap & Hold: Hold both modifiers.
+  ;;
+  ;; Notes:
+  ;;  - The tap counter resets after its defined timeout period.
+  ;;  - The sticky keys expire after their defined timeout period.
   ;;
   ;; Important: For this to work, you must compile KMomad from source with the
   ;; patch from https://github.com/kmonad/kmonad/pull/1014 (commit 21744cc).

--- a/Linux/KMonad/keeb-utils.kbd
+++ b/Linux/KMonad/keeb-utils.kbd
@@ -8,7 +8,6 @@ License     : MIT
 ;;
 ;; KMonad General Configuration
 ;;
-
 ;; The 'defcfg' block defines global configuration options of KMonad. This
 ;; includes the input and output devices, and customizing various behaviors.
 ;; This block must contain at least one input() and one output() function for
@@ -40,7 +39,6 @@ License     : MIT
 ;;
 ;; Keymaps
 ;;
-
 ;; The 'defsrc' block defines the source keyboard layout -- this is the layout
 ;; of the host operating system. It's advised to keep it US QWERTY, unless you
 ;; have a good reason to use another layout, because the output may produce
@@ -163,7 +161,6 @@ License     : MIT
 ;;
 ;; Aliases
 ;;
-
 ;; The 'defalias' block defines aliases -- they are used to identify custom
 ;; keymaps, key combinations, and macros. Also, alias definitions can be used
 ;; to alter the behavior of keys: for example, do one thing on key tap, do

--- a/Linux/KMonad/keeb-utils.kbd
+++ b/Linux/KMonad/keeb-utils.kbd
@@ -177,7 +177,7 @@ License     : MIT
   ;; Layers
   xtn (layer-toggle extend)
   sel (layer-toggle select-layout)
-  sym (tap-next lalt (layer-toggle symbols)) ;; LAlt on tap, Symbols on hold.
+  sym (tap-next lalt (layer-toggle symbols))
   ssm (layer-toggle shifted-symbols)
 
   ;; Ctrl Shortcuts

--- a/README.md
+++ b/README.md
@@ -8,25 +8,23 @@
 
 # Keeb Utils
 
-Keeb Utils, “Keyboard Utilities”, is a collection of my custom keyboard layout and layers for Windows and Linux, aimed at improving typing efficiency, ergonomics, and comfort. It's designed for both keyboard enthusiasts and newcomers, inspired by the work of others.
+Keeb Utils, “Keyboard Utilities,” is a collection of my custom keyboard layout and layers to improve keyboard ergonomics and productivity. The project was inspired by the work of others in the alternative keyboard layouts community.
 
 Keeb Utils adheres to these key principles:
-
 - **Keep it functional and minimal:** don't implement flashy, rarely used features that will require extra maintenance in the future.
 - **Implement cross-platform solutions without sacrificing essential features:** make sure a feature provided by one software solution is possible to implement in another.
-- **Maintain high modularity:** functions are declared in modules wherever possible allowing for swapping them out easily for testing and other purposes.
+- **Maintain high modularity:** functions are declared in modules wherever possible allowing for swapping them out easily for customization.
 
 Keeb Utils employs technics provided by third-party software to remap the keys of your keyboard on the operating system level:
-
-- On **Linux** via **KMonad** version >=**0.4.1**
-- On **Windows** via **AutoHotkey** version >=**2.0**
+- On **Linux** via **KMonad**
+- On **Windows** via **AutoHotkey**
 
 ## Keyboard Layout
 
-I use a keyboard layout known as “Colemak-DH“ (which is occasionally referred to as “Colemak Mod-DH“). Colemak was originally created in 2006 primarily for the English lanaguage. It was enhanced in 2015 with the addition of the “DH“ modification, which involved swapping the D and H keys to minimize the side-to-side movement of the index fingers.
+I use the Colemak-DH keyboard layout. Colemak was created in 2006 for the English language. In 2015, the DH ergonomic modification improved the layout. This change swapped the D and H keys to reduce side-to-side finger movement.
 
 More information on Colemak: https://colemak.com/  
-More information on Colemak Mod DH: https://colemakmods.github.io/mod-dh
+More information on the DH ergo mod: https://colemakmods.github.io/mod-dh
 
 <div align="center">
 
@@ -37,11 +35,17 @@ More information on Colemak Mod DH: https://colemakmods.github.io/mod-dh
 
 ## Keyboard Layers
 
-To extend the functionality or make certain functions more accessible, Keeb Utils implements keyboard layers which can be used by special key combinations. Similarly to using <kbd>Ctrl</kbd>+<kbd>C</kbd> to copy text, <kbd>Alt</kbd>+<kbd>Tab</kbd> to switch between the active window, and so on.
+To extend the functionality or make certain functions more accessible, Keeb Utils implements extra keyboard layers which can be used by special key combinations. Similarly to using <kbd>Ctrl</kbd>+<kbd>C</kbd> to copy text, <kbd>Alt</kbd>+<kbd>Tab</kbd> to switch between the active window, and so on.
 
 ### Extend Layer
 
 The Extend layer is designed for a keyboard-focused workflow in mind by providing quick access to essential text editing and navigation features. Activating this layer with a designated key (<kbd>Caps Lock</kbd> by default) allows you to perform these tasks directly from the alphanumeric keys.
+
+**Advantages to using Extend:**
+- **Stay on the home row:** Keep your hands in the typing position. This reduces wrist movement and fatigue.
+- **Faster navigation:** Use <kbd>U</kbd>, <kbd>N</kbd>, <kbd>E</kbd>, and <kbd>I</kbd> as arrow keys (QWERTY <kbd>I</kbd>, <kbd>J</kbd>, <kbd>K</kbd>, and <kbd>L</kbd>).
+- **Power editing:** Access <kbd>Home</kbd>, <kbd>End</kbd>, <kbd>PgUp</kbd>, <kbd>PgDn</kbd>, <kbd>Del</kbd>, and <kbd>Backspace</kbd> without reaching across the keyboard.
+- **Integrated shortcuts:** Perform complex actions like "Select Next Word" or "Close Tab" using home row modifiers or tap dance actions.
 
 <div align="center">
 
@@ -52,36 +56,47 @@ The Extend layer is designed for a keyboard-focused workflow in mind by providin
 
 | Key Category  | Description |
 | :-----------: | ----------- |
-| ![Navigation keys](Assets/Images/Keyboard%20Layers/extend-blue.png) | Navigation keys (e.g., <kbd>Left</kbd> <kbd>Up</kbd> <kbd>PgDn</kbd> etc.) |
-| ![Ctrl shortcuts](Assets/Images/Keyboard%20Layers/extend-green.png) | Ctrl shortcuts (e.g., <kbd>Ctrl</kbd>+<kbd>C</kbd> <kbd>Ctrl</kbd>+<kbd>V</kbd> etc.) |
-| ![Modifiers](Assets/Images/Keyboard%20Layers/extend-orange.png) | Modifiers (e.g., <kbd>Win</kbd> <kbd>Shift</kbd> <kbd>Ctrl</kbd> etc.) |
-| ![Sticky keys](Assets/Images/Keyboard%20Layers/extend-sticky.png) | Sticky keys<b>*</b> |
-| ![Multi-Sticky keys](Assets/Images/Keyboard%20Layers/extend-multi-sticky.png) | Sticky keys combined with multi-tap<b>**</b> |
-| ![Text manipulation keys](Assets/Images/Keyboard%20Layers/extend-red.png) | Text manipulation (e.g., <kbd>Backspace</kbd> <kbd>Caps Lock</kbd> <kbd>Tab</kbd> etc.) |
-| ![Multimedia keys](Assets/Images/Keyboard%20Layers/extend-light-green.png) | Multimedia keys (e.g., <kbd>Play</kbd> <kbd>Vol. Down</kbd> <kbd>Vol. Up</kbd> etc.) |
+| ![Navigation keys](Assets/Images/Keyboard%20Layers/extend-blue.png) | Navigation keys |
+| ![Ctrl shortcuts](Assets/Images/Keyboard%20Layers/extend-green.png) | Ctrl shortcuts |
+| ![Modifiers](Assets/Images/Keyboard%20Layers/extend-orange.png) | Modifiers |
+| ![Sticky keys](Assets/Images/Keyboard%20Layers/extend-sticky.png) | Sticky keys (see below this table) |
+| ![Multi-Sticky keys](Assets/Images/Keyboard%20Layers/extend-multi-sticky.png) | Sticky keys combined with multi-tap (see below this table) |
+| ![Text manipulation keys](Assets/Images/Keyboard%20Layers/extend-red.png) | Text manipulation |
+| ![Multimedia keys](Assets/Images/Keyboard%20Layers/extend-light-green.png) | Multimedia keys |
 | ![Misc. keys](Assets/Images/Keyboard%20Layers/extend-grey.png) | Function and misc. keys |
 
-<b>*</b> **Sticky key implemented with** <kbd>Shift</kbd>:
+#### Advanced Modifiers (Sticky Keys)
 
-- **Tapped:** <kbd>Shift</kbd> becomes sticky until the next key press.
-- **Held:** Holds <kbd>Shift</kbd> until the key is released.
+**Shift Key:**
+- **Tap**: Activates <kbd>Shift</kbd> for the next key press only. It expires after 450 ms if no key is pressed.
+- **Hold**: Acts like a normal <kbd>Shift</kbd> key.
 
-*Note: The stickiness expires when the timeout is over (450 milliseconds by default).*
+**Multi-Modifier Combinations** (Ctrl/Alt and Shift):  
+You can combine modifiers by tapping them quickly (within 175 ms).
 
-<b>**</b> **Combination of multi-tap and sticky keys with** <kbd>Ctrl</kbd>, <kbd>Ctrl</kbd>+<kbd>Shift</kbd> **and** <kbd>Alt</kbd>, <kbd>Alt</kbd>+<kbd>Shift</kbd>:
+**Using Ctrl:**
+- **Single Tap**: Activates <kbd>Ctrl</kbd> for the next key press.
+- **Single Tap & Hold**: Holds <kbd>Ctrl</kbd> down continuously.
+- **Double Tap**: Activates both <kbd>Ctrl</kbd> and <kbd>Shift</kbd> for the next key press.
+- **Double Tap & Hold**: Holds both <kbd>Ctrl</kbd> and <kbd>Shift</kbd> down continuously.
 
-- **Single Tap:** Sticky the modifier for the next key press then release.
-    - **Single Tap & Hold:** Hold the modifier.
-- **Double Tap:** Sticky both modifiers (<kbd>Ctrl</kbd> or <kbd>Alt</kbd> with <kbd>Shift</kbd>) for the next key press then release.
-    - **Double Tap & Hold:** Hold both modifiers (<kbd>Ctrl</kbd> or <kbd>Alt</kbd> with <kbd>Shift</kbd>).
+**Using Alt:**
+- **Single Tap**: Activates <kbd>Alt</kbd> for the next key press.
+- **Single Tap & Hold**: Holds <kbd>Alt</kbd> down continuously.
+- **Double Tap**: Activates both <kbd>Alt</kbd> and <kbd>Shift</kbd> for the next key press.
+- **Double Tap & Hold**: Holds both <kbd>Alt</kbd> and <kbd>Shift</kbd> down continuously.
 
-*Notes:*
-- *A double tap must be registered within 175 milliseconds otherwise the multi-tap function expires. The stickiness expires when the timeout is over (450 milliseconds by default).*
-- *This is the solution to fix the issue of* <kbd>Ctrl</kbd>/<kbd>Alt</kbd> *and* <kbd>Shift</kbd> *not combining with the* `sticky-key` *function in KMonad (see: https://github.com/kmonad/kmonad/discussions/1013).*
+**Why this is used:** KMonad doesn't combine multiple sticky modifiers. This implementation ensures that combinations like <kbd>Ctrl</kbd>+<kbd>Shift</kbd> work reliably across all applications.
 
 ### Symbols Layer
 
 The Symbols layer provides quick access to commonly used symbols and punctuation marks by holding a designated key (<kbd>Left Alt</kbd> by default) improving typing ergonomics and reducing errors.
+
+**Advantages to using Symbols:**
+- **Reduces finger travel**: You can access symbols like `<`, `-`, `>`, and `( )` without leaving the home row.
+- **Balanced workflow**: Symbols are distributed across both hands to prevent “one-handed” strain.
+- **Ergonomic placement**: Brackets and math operators are grouped logically, making them easier to remember than the standard Shift+Number combinations.
+- **Fewer errors**: Because your hands stay in the home position, you are less likely to lose your place or make a typo when switching between text and code.
 
 <div align="center">
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 Keeb Utils, “Keyboard Utilities,” is a collection of my custom keyboard layout and layers to improve keyboard ergonomics and productivity. The project was inspired by the work of others in the alternative keyboard layouts community.
 
 Keeb Utils adheres to these key principles:
-- **Keep it functional and minimal:** don't implement flashy, rarely used features that will require extra maintenance in the future.
-- **Implement cross-platform solutions without sacrificing essential features:** make sure a feature provided by one software solution is possible to implement in another.
-- **Maintain high modularity:** functions are declared in modules wherever possible allowing for swapping them out easily for customization.
+- **Keep it functional and minimal**: don't implement flashy, rarely used features that will require extra maintenance in the future.
+- **Implement cross-platform solutions without sacrificing essential features**: make sure a feature provided by one software solution is possible to implement in another.
+- **Maintain high modularity**: functions are declared in modules wherever possible allowing for swapping them out easily for customization.
 
 Keeb Utils employs technics provided by third-party software to remap the keys of your keyboard on the operating system level:
 - On **Linux** via **KMonad**
@@ -41,11 +41,11 @@ To extend the functionality or make certain functions more accessible, Keeb Util
 
 The Extend layer is designed for a keyboard-focused workflow in mind by providing quick access to essential text editing and navigation features. Activating this layer with a designated key (<kbd>Caps Lock</kbd> by default) allows you to perform these tasks directly from the alphanumeric keys.
 
-**Advantages to using Extend:**
-- **Stay on the home row:** Keep your hands in the typing position. This reduces wrist movement and fatigue.
-- **Faster navigation:** Use <kbd>U</kbd>, <kbd>N</kbd>, <kbd>E</kbd>, and <kbd>I</kbd> as arrow keys (QWERTY <kbd>I</kbd>, <kbd>J</kbd>, <kbd>K</kbd>, and <kbd>L</kbd>).
-- **Power editing:** Access <kbd>Home</kbd>, <kbd>End</kbd>, <kbd>PgUp</kbd>, <kbd>PgDn</kbd>, <kbd>Del</kbd>, and <kbd>Backspace</kbd> without reaching across the keyboard.
-- **Integrated shortcuts:** Perform complex actions like "Select Next Word" or "Close Tab" using home row modifiers or tap dance actions.
+**Advantages to using Extend**:
+- **Stay on the home row**: Keep your hands in the typing position. This reduces wrist movement and fatigue.
+- **Faster navigation**: Use <kbd>U</kbd>, <kbd>N</kbd>, <kbd>E</kbd>, and <kbd>I</kbd> as arrow keys (QWERTY <kbd>I</kbd>, <kbd>J</kbd>, <kbd>K</kbd>, and <kbd>L</kbd>).
+- **Power editing**: Access <kbd>Home</kbd>, <kbd>End</kbd>, <kbd>PgUp</kbd>, <kbd>PgDn</kbd>, <kbd>Del</kbd>, and <kbd>Backspace</kbd> without reaching across the keyboard.
+- **Integrated shortcuts**: Perform complex actions like "Select Next Word" or "Close Tab" using home row modifiers or tap dance actions.
 
 <div align="center">
 
@@ -67,32 +67,32 @@ The Extend layer is designed for a keyboard-focused workflow in mind by providin
 
 #### Advanced Modifiers (Sticky Keys)
 
-**Shift Key:**
+**Shift Key**:
 - **Tap**: Activates <kbd>Shift</kbd> for the next key press only. It expires after 450 ms if no key is pressed.
 - **Hold**: Acts like a normal <kbd>Shift</kbd> key.
 
 **Multi-Modifier Combinations** (Ctrl/Alt and Shift):  
 You can combine modifiers by tapping them quickly (within 175 ms).
 
-**Using Ctrl:**
+**Using Ctrl**:
 - **Single Tap**: Activates <kbd>Ctrl</kbd> for the next key press.
 - **Single Tap & Hold**: Holds <kbd>Ctrl</kbd> down continuously.
 - **Double Tap**: Activates both <kbd>Ctrl</kbd> and <kbd>Shift</kbd> for the next key press.
 - **Double Tap & Hold**: Holds both <kbd>Ctrl</kbd> and <kbd>Shift</kbd> down continuously.
 
-**Using Alt:**
+**Using Alt**:
 - **Single Tap**: Activates <kbd>Alt</kbd> for the next key press.
 - **Single Tap & Hold**: Holds <kbd>Alt</kbd> down continuously.
 - **Double Tap**: Activates both <kbd>Alt</kbd> and <kbd>Shift</kbd> for the next key press.
 - **Double Tap & Hold**: Holds both <kbd>Alt</kbd> and <kbd>Shift</kbd> down continuously.
 
-**Why this is used:** KMonad doesn't combine multiple sticky modifiers. This implementation ensures that combinations like <kbd>Ctrl</kbd>+<kbd>Shift</kbd> work reliably across all applications.
+**Why this is used**: KMonad doesn't combine multiple sticky modifiers. This implementation ensures that combinations like <kbd>Ctrl</kbd>+<kbd>Shift</kbd> work reliably across all applications.
 
 ### Symbols Layer
 
 The Symbols layer provides quick access to commonly used symbols and punctuation marks by holding a designated key (<kbd>Left Alt</kbd> by default) improving typing ergonomics and reducing errors.
 
-**Advantages to using Symbols:**
+**Advantages to using Symbols**:
 - **Reduces finger travel**: You can access symbols like `<`, `-`, `>`, and `( )` without leaving the home row.
 - **Balanced workflow**: Symbols are distributed across both hands to prevent “one-handed” strain.
 - **Ergonomic placement**: Brackets and math operators are grouped logically, making them easier to remember than the standard Shift+Number combinations.

--- a/Windows/AutoHotkey/Layers/Lib/multi-sticky.ahk
+++ b/Windows/AutoHotkey/Layers/Lib/multi-sticky.ahk
@@ -27,11 +27,8 @@ MultiSticky(tapTimeout := 175,
             secondaryKey := "") {
 
     ;; Extract the scan code from the key that called the function.
-    ;; Important: The function must be mapped to a key defined using
-    ;; its scan code (e.g., "sc020").
-    triggerKey := A_ThisHotkey
-    triggerKey := RegExMatch(triggerKey, "sc\d+", &OutputVar)
-    triggerKey := OutputVar[]
+    RegExMatch(A_ThisHotkey, "i)sc[0-9A-F]+|.", &match)
+    triggerKey := match[0]
 
     ;; Implement the tap counting logic.
     static keyPresses := 0

--- a/Windows/AutoHotkey/Layers/Lib/multi-sticky.ahk
+++ b/Windows/AutoHotkey/Layers/Lib/multi-sticky.ahk
@@ -3,60 +3,60 @@
  * Description : AutoHotkey Multi-Sticky Key function (Keeb Utils)
  * Copyright   : (c) 2025, Gergely Szabo
  * License     : MIT
+ *
+ * Implement a multi-tap sticky key function to combine two modifiers into
+ * a single key:
+ *  - Single Tap & Release: Sticky the primary modifier for the next key press.
+ *    - Single Tap & Hold: Hold the primary modifier.
+ *  - Double Tap & Release: Sticky the primary and secondary modifiers for the
+ *                          next key press.
+ *    - Double Tap & Hold: Hold both modifiers.
+ *
+ * Notes:
+ *  - The tap counter resets after its defined timeout period.
+ *  - The sticky keys expire after their defined timeout period.
+ *
+ * Example Usage:
+ *  Shift & sc020::MultiSticky(175, "Ctrl", 450, "Shift")
  */
 
-/**
- * @description Implements a multi-tap sticky key behavior emulating KMonad's
- *  combination of 'multi-tap' and 'sticky-key' functions.
- * @caution The function must be mapped to a key defined with its scan code.
- * @var {string} keySC The scan code of the key that called the function. This
- *  is used to determine the key's physical state to initiate a tap or hold
- *  action.
- * @var {integer} keyPresses Static variable to count the number of taps. It is
- *  reset when multiTapTimeout expires or the function completes.
- * @param {integer} multiTapTimeout Duration in milliseconds to wait for the
- * second tap.
- * @param {string} primaryKey The primary key to sticky with a timeout on tap,
- *  or to hold while keySC is held.
- * @param {integer} stickyKeyTimeout Duration in milliseconds to sticky the
- *  primaryKey when keySC is tapped, or sticky the primaryKey and secondaryKey
- *  on a double tap.
- * @param {string} secondaryKey The secondary key to sticky with the primaryKey
- *  on a double tap, or to hold with the primaryKey on a double tap and hold
- *  while keySC is held.
- * @returns None.
- * @example Shift & sc020::MultiSticky(175, "Ctrl", 450, "Shift")
- */
-MultiSticky(multiTapTimeout := 175,
+MultiSticky(tapTimeout := 175,
             primaryKey := "",
-            stickyKeyTimeout := 450,
+            stickyTimeout := 450,
             secondaryKey := "") {
-    keySC := A_ThisHotkey
-    keySC := RegExMatch(keySC, "sc\d+", &OutputVar)
-    keySC := OutputVar[]
 
+    ;; Extract the scan code from the key that called the function.
+    ;; Important: The function must be mapped to a key defined using its scan
+    ;; code (e.g., "sc020").
+    triggerKey := A_ThisHotkey
+    triggerKey := RegExMatch(triggerKey, "sc\d+", &OutputVar)
+    triggerKey := OutputVar[]
+
+    ;; Create the tap counter.
     static keyPresses := 0
     if (keyPresses > 0) {
         keyPresses += 1
         Return
     }
 
+    ;; Start the tap counter on the first key press; the counter resets after
+    ;; the timeout defined by 'tapTimeout' in milliseconds.
     keyPresses := 1
-    SetTimer Taps, -multiTapTimeout
+    SetTimer Taps, -tapTimeout
 
     Taps() {
         ;; Single Tap
         if (keyPresses = 1) {
             Send "{Blind}{" primaryKey " Down}"
-            Sleep stickyKeyTimeout
+            Sleep stickyTimeout
 
             ;; Single Tap & Hold
-            if !KeyWait(keySC) {
+            if !KeyWait(triggerKey) {
                 Send "{Blind}{" primaryKey " Down}"
             }
 
             ;; Release
-            KeyWait keySC
+            KeyWait triggerKey
             Send "{" primaryKey " Up}"
         }
 
@@ -64,16 +64,16 @@ MultiSticky(multiTapTimeout := 175,
         if (keyPresses = 2) {
             Send "{Blind}{" primaryKey " Down}"
             Send "{Blind}{" secondaryKey " Down}"
-            Sleep stickyKeyTimeout
+            Sleep stickyTimeout
 
             ;; Double Tap & Hold
-            if !KeyWait(keySC) {
+            if !KeyWait(triggerKey) {
                 Send "{Blind}{" primaryKey " Down}"
                 Send "{Blind}{" secondaryKey " Down}"
             }
 
             ;; Release
-            KeyWait keySC
+            KeyWait triggerKey
             Send "{" primaryKey " Up}"
             Send "{" secondaryKey " Up}"
         }

--- a/Windows/AutoHotkey/Layers/Lib/multi-sticky.ahk
+++ b/Windows/AutoHotkey/Layers/Lib/multi-sticky.ahk
@@ -21,9 +21,9 @@
  * @var {string} triggerKey    Scan code of the key that called the function. Important: The key the functions is mapped to must be defined using its scan code (e.g., "sc020").
  * @var {int} keyPresses    Stores the number of taps detected within 'tapTimeout'.
  */
-MultiSticky(tapTimeout := 175,
+MultiSticky(tapTimeout := 0,
             primaryKey := "",
-            stickyTimeout := 450,
+            stickyTimeout := 0,
             secondaryKey := "") {
 
     ;; Extract the scan code from the key that called the function.

--- a/Windows/AutoHotkey/Layers/Lib/multi-sticky.ahk
+++ b/Windows/AutoHotkey/Layers/Lib/multi-sticky.ahk
@@ -1,7 +1,7 @@
 /*
  * File        : multi-sticky.ahk
  * Description : AutoHotkey Multi-Sticky Key function (Keeb Utils)
- * Copyright   : (c) 2025, Gergely Szabo
+ * Copyright   : (c) 2025-2026, Gergely Szabo
  * License     : MIT
  *
  * Implement a multi-tap sticky key function to combine two modifiers into

--- a/Windows/AutoHotkey/Layers/Lib/multi-sticky.ahk
+++ b/Windows/AutoHotkey/Layers/Lib/multi-sticky.ahk
@@ -27,7 +27,7 @@ MultiSticky(tapTimeout := 0,
             secondaryKey := "") {
 
     ;; Extract the scan code from the key that called the function.
-    RegExMatch(A_ThisHotkey, "sc\d+", &match)
+    RegExMatch(A_ThisHotkey, "i)sc\d+", &match)
     triggerKey := match[0]
 
     ;; Implement the tap counting logic.

--- a/Windows/AutoHotkey/Layers/Lib/multi-sticky.ahk
+++ b/Windows/AutoHotkey/Layers/Lib/multi-sticky.ahk
@@ -27,7 +27,7 @@ MultiSticky(tapTimeout := 0,
             secondaryKey := "") {
 
     ;; Extract the scan code from the key that called the function.
-    RegExMatch(A_ThisHotkey, "i)sc[0-9A-F]+|.", &match)
+    RegExMatch(A_ThisHotkey, "sc\d+", &match)
     triggerKey := match[0]
 
     ;; Implement the tap counting logic.

--- a/Windows/AutoHotkey/Layers/Lib/multi-sticky.ahk
+++ b/Windows/AutoHotkey/Layers/Lib/multi-sticky.ahk
@@ -25,7 +25,6 @@ MultiSticky(tapTimeout := 0,
             primaryKey := "",
             stickyTimeout := 0,
             secondaryKey := "") {
-
     ;; Extract the scan code from the key that called the function.
     RegExMatch(A_ThisHotkey, "i)sc\d+", &match)
     triggerKey := match[0]

--- a/Windows/AutoHotkey/Layers/Lib/multi-sticky.ahk
+++ b/Windows/AutoHotkey/Layers/Lib/multi-sticky.ahk
@@ -4,23 +4,23 @@
  * Copyright   : (c) 2025-2026, Gergely Szabo
  * License     : MIT
  *
- * Implement a multi-tap sticky key function to combine two modifiers
- * into a single key:
- *  - Single Tap & Release: Sticky the primary modifier
- *                          for the next key press.
- *    - Single Tap & Hold: Hold the primary modifier.
- *  - Double Tap & Release: Sticky the primary and secondary modifiers
- *                          for the next key press. 
- *    - Double Tap & Hold: Hold both modifiers.
- *
- * Notes:
- *  - The tap counter resets after its defined timeout period.
- *  - The sticky keys expire after their defined timeout period.
+ * This function implements sticky and held behaviors for modifier keys, it
+ * also combines two modifiers into one physical key for the same behaviors.
+ * The function uses a timer to count the number of taps to determine if one
+ * modifier or two modifiers should be activated.
  *
  * Example Usage:
  *  Shift & sc020::MultiSticky(175, "Ctrl", 450, "Shift")
  */
 
+/**
+ * @param {int} tapTimeout    Max ms between taps to increment count.
+ * @param {string} primaryKey    Primary modifier (e.g., "Ctrl").
+ * @param {int} stickyTimeout    Sticky-time after a tap-and-release.
+ * @param {string} secondaryKey    Modifier added on double-tap (e.g., "Shift").
+ * @var {string} triggerKey    Scan code of the key that called the function. Important: The key the functions is mapped to must be defined using its scan code (e.g., "sc020").
+ * @var {int} keyPresses    Stores the number of taps detected within 'tapTimeout'.
+ */
 MultiSticky(tapTimeout := 175,
             primaryKey := "",
             stickyTimeout := 450,
@@ -33,47 +33,39 @@ MultiSticky(tapTimeout := 175,
     triggerKey := RegExMatch(triggerKey, "sc\d+", &OutputVar)
     triggerKey := OutputVar[]
 
-    ;; Create the tap counter.
+    ;; Implement the tap counting logic.
     static keyPresses := 0
     if (keyPresses > 0) {
         keyPresses += 1
         Return
     }
-
-    ;; Start the tap counter on the first key press; the counter resets
-    ;; after the timeout defined by 'tapTimeout' in milliseconds.
     keyPresses := 1
     SetTimer Taps, -tapTimeout
 
+    ;; Key state handling.
     Taps() {
-        ;; Single Tap
         if (keyPresses = 1) {
             Send "{Blind}{" primaryKey " Down}"
             Sleep stickyTimeout
 
-            ;; Single Tap & Hold
             if !KeyWait(triggerKey) {
                 Send "{Blind}{" primaryKey " Down}"
             }
 
-            ;; Release
             KeyWait triggerKey
             Send "{" primaryKey " Up}"
         }
 
-        ;; Double Tap
         if (keyPresses = 2) {
             Send "{Blind}{" primaryKey " Down}"
             Send "{Blind}{" secondaryKey " Down}"
             Sleep stickyTimeout
 
-            ;; Double Tap & Hold
             if !KeyWait(triggerKey) {
                 Send "{Blind}{" primaryKey " Down}"
                 Send "{Blind}{" secondaryKey " Down}"
             }
 
-            ;; Release
             KeyWait triggerKey
             Send "{" primaryKey " Up}"
             Send "{" secondaryKey " Up}"

--- a/Windows/AutoHotkey/Layers/Lib/multi-sticky.ahk
+++ b/Windows/AutoHotkey/Layers/Lib/multi-sticky.ahk
@@ -4,12 +4,13 @@
  * Copyright   : (c) 2025-2026, Gergely Szabo
  * License     : MIT
  *
- * Implement a multi-tap sticky key function to combine two modifiers into
- * a single key:
- *  - Single Tap & Release: Sticky the primary modifier for the next key press.
+ * Implement a multi-tap sticky key function to combine two modifiers
+ * into a single key:
+ *  - Single Tap & Release: Sticky the primary modifier
+ *                          for the next key press.
  *    - Single Tap & Hold: Hold the primary modifier.
- *  - Double Tap & Release: Sticky the primary and secondary modifiers for the
- *                          next key press.
+ *  - Double Tap & Release: Sticky the primary and secondary modifiers
+ *                          for the next key press. 
  *    - Double Tap & Hold: Hold both modifiers.
  *
  * Notes:
@@ -26,8 +27,8 @@ MultiSticky(tapTimeout := 175,
             secondaryKey := "") {
 
     ;; Extract the scan code from the key that called the function.
-    ;; Important: The function must be mapped to a key defined using its scan
-    ;; code (e.g., "sc020").
+    ;; Important: The function must be mapped to a key defined using
+    ;; its scan code (e.g., "sc020").
     triggerKey := A_ThisHotkey
     triggerKey := RegExMatch(triggerKey, "sc\d+", &OutputVar)
     triggerKey := OutputVar[]
@@ -39,8 +40,8 @@ MultiSticky(tapTimeout := 175,
         Return
     }
 
-    ;; Start the tap counter on the first key press; the counter resets after
-    ;; the timeout defined by 'tapTimeout' in milliseconds.
+    ;; Start the tap counter on the first key press; the counter resets
+    ;; after the timeout defined by 'tapTimeout' in milliseconds.
     keyPresses := 1
     SetTimer Taps, -tapTimeout
 

--- a/Windows/AutoHotkey/Layers/Lib/multi-sticky.ahk
+++ b/Windows/AutoHotkey/Layers/Lib/multi-sticky.ahk
@@ -34,7 +34,7 @@ MultiSticky(tapTimeout := 0,
     static keyPresses := 0
     if (keyPresses > 0) {
         keyPresses += 1
-        Return
+        return
     }
     keyPresses := 1
     SetTimer Taps, -tapTimeout

--- a/Windows/AutoHotkey/Layers/Lib/sticky-key.ahk
+++ b/Windows/AutoHotkey/Layers/Lib/sticky-key.ahk
@@ -18,7 +18,7 @@
 StickyKey(stickyTimeout := 0, keyName := "") {
 
     ;; Extract the scan code from the key that called the function.
-    RegExMatch(A_ThisHotkey, "i)sc[0-9A-F]+|.", &match)
+    RegExMatch(A_ThisHotkey, "sc\d+", &match)
     triggerKey := match[0]
 
     Send "{Blind}{" keyName " Down}"

--- a/Windows/AutoHotkey/Layers/Lib/sticky-key.ahk
+++ b/Windows/AutoHotkey/Layers/Lib/sticky-key.ahk
@@ -3,37 +3,38 @@
  * Description : AutoHotkey Sticky Key function (Keeb Utils)
  * Copyright   : (c) 2025, Gergely Szabo
  * License     : MIT
+ * 
+ * Implement a sticky key function to change the behavior of a modifier key
+ * with support for tap and hold actions:
+ *  - Tap & Release: Sticky the modifier for the next key press.
+ *  - Tap & Hold: Hold the modifier while the physical key is held.
+ * 
+ * Notes:
+ *  - The sticky key expires after its defined timeout period.
+ * 
+ * Example Usage:
+ *  Shift & sc020::StickyKey(450, "Ctrl")
  */
 
-/**
- * @description Implements a sticky key behavior that simulates a virtual key
- *  press with support for tap and hold actions.
- * @caution The function must be mapped to a key defined with its scan code.
- * @var {string} keySC The scan code of the key that called the function. This
- *  is used to determine the key's physical state to initiate the tap or
- *  hold action.
- * @param {integer} stickyKeyTimeout Duration in milliseconds to sticky keyName
- *  when keySC was tapped.
- * @param {string} keyName The key to sticky with a timeout on tap, or to hold
- *  while keySC is held.
- * @returns None.
- * @example Shift & sc020::StickyKey(450, "Ctrl")
- */
-StickyKey(stickyKeyTimeout := 450, keyName := "") {
-    keySC := A_ThisHotkey
-    keySC := RegExMatch(keySC, "sc\d+", &OutputVar)
-    keySC := OutputVar[]
+StickyKey(stickyTimeout := 450, keyName := "") {
+
+    ;; Extract the scan code from the key that called the function.
+    ;; Important: The function must be mapped to a key defined using its scan
+    ;; code (e.g., "sc020").
+    triggerKey := A_ThisHotkey
+    triggerKey := RegExMatch(triggerKey, "sc\d+", &OutputVar)
+    triggerKey := OutputVar[]
 
     ;; On Tap
     Send "{Blind}{" keyName " Down}"
-    Sleep stickyKeyTimeout
+    Sleep stickyTimeout
 
     ;; On Hold
-    if !KeyWait(keySC) {
+    if !KeyWait(triggerKey) {
         Send "{Blind}{" keyName " Down}"
     }
 
     ;; On Release
-    KeyWait keySC
+    KeyWait triggerKey
     Send "{" keyName " Up}"
 }

--- a/Windows/AutoHotkey/Layers/Lib/sticky-key.ahk
+++ b/Windows/AutoHotkey/Layers/Lib/sticky-key.ahk
@@ -4,37 +4,30 @@
  * Copyright   : (c) 2025-2026, Gergely Szabo
  * License     : MIT
  *
- * Implement a sticky key function to change the behavior of a modifier
- * key with support for tap and hold actions:
- *  - Tap & Release: Sticky the modifier for the next key press.
- *  - Tap & Hold: Hold the modifier while the physical key is held.
- *
- * Notes:
- *  - The sticky key expires after its defined timeout period.
+ * This function implements sticky and hold behaviors for modifier keys.
  *
  * Example Usage:
  *  Shift & sc020::StickyKey(450, "Ctrl")
  */
 
+/**
+ * @param {int} stickyTimeout    Sticky-time after a tap-and-release.
+ * @param {string} keyName    Name of the modifier key to sticky or hold (e.g., "Ctrl").
+ * @var {string} triggerKey    Scan code of the key that called the function. Important: The key the functions is mapped to must be defined using its scan code (e.g., "sc020"). 
+ */
 StickyKey(stickyTimeout := 450, keyName := "") {
 
     ;; Extract the scan code from the key that called the function.
-    ;; Important: The function must be mapped to a key defined using
-    ;; its scan code (e.g., "sc020").
-    triggerKey := A_ThisHotkey
-    triggerKey := RegExMatch(triggerKey, "sc\d+", &OutputVar)
-    triggerKey := OutputVar[]
+    RegExMatch(A_ThisHotkey, "i)sc[0-9A-F]+|.", &match)
+    triggerKey := match[0]
 
-    ;; On Tap
     Send "{Blind}{" keyName " Down}"
     Sleep stickyTimeout
 
-    ;; On Hold
     if !KeyWait(triggerKey) {
         Send "{Blind}{" keyName " Down}"
     }
 
-    ;; On Release
     KeyWait triggerKey
     Send "{" keyName " Up}"
 }

--- a/Windows/AutoHotkey/Layers/Lib/sticky-key.ahk
+++ b/Windows/AutoHotkey/Layers/Lib/sticky-key.ahk
@@ -16,7 +16,6 @@
  * @var {string} triggerKey    Scan code of the key that called the function. Important: The key the functions is mapped to must be defined using its scan code (e.g., "sc020").
  */
 StickyKey(stickyTimeout := 0, keyName := "") {
-
     ;; Extract the scan code from the key that called the function.
     RegExMatch(A_ThisHotkey, "i)sc\d+", &match)
     triggerKey := match[0]

--- a/Windows/AutoHotkey/Layers/Lib/sticky-key.ahk
+++ b/Windows/AutoHotkey/Layers/Lib/sticky-key.ahk
@@ -1,7 +1,7 @@
 /*
  * File        : sticky-key.ahk
  * Description : AutoHotkey Sticky Key function (Keeb Utils)
- * Copyright   : (c) 2025, Gergely Szabo
+ * Copyright   : (c) 2025-2026, Gergely Szabo
  * License     : MIT
  * 
  * Implement a sticky key function to change the behavior of a modifier key

--- a/Windows/AutoHotkey/Layers/Lib/sticky-key.ahk
+++ b/Windows/AutoHotkey/Layers/Lib/sticky-key.ahk
@@ -3,15 +3,15 @@
  * Description : AutoHotkey Sticky Key function (Keeb Utils)
  * Copyright   : (c) 2025-2026, Gergely Szabo
  * License     : MIT
- * 
- * Implement a sticky key function to change the behavior of a modifier key
- * with support for tap and hold actions:
+ *
+ * Implement a sticky key function to change the behavior of a modifier
+ * key with support for tap and hold actions:
  *  - Tap & Release: Sticky the modifier for the next key press.
  *  - Tap & Hold: Hold the modifier while the physical key is held.
- * 
+ *
  * Notes:
  *  - The sticky key expires after its defined timeout period.
- * 
+ *
  * Example Usage:
  *  Shift & sc020::StickyKey(450, "Ctrl")
  */
@@ -19,8 +19,8 @@
 StickyKey(stickyTimeout := 450, keyName := "") {
 
     ;; Extract the scan code from the key that called the function.
-    ;; Important: The function must be mapped to a key defined using its scan
-    ;; code (e.g., "sc020").
+    ;; Important: The function must be mapped to a key defined using
+    ;; its scan code (e.g., "sc020").
     triggerKey := A_ThisHotkey
     triggerKey := RegExMatch(triggerKey, "sc\d+", &OutputVar)
     triggerKey := OutputVar[]

--- a/Windows/AutoHotkey/Layers/Lib/sticky-key.ahk
+++ b/Windows/AutoHotkey/Layers/Lib/sticky-key.ahk
@@ -15,7 +15,7 @@
  * @param {string} keyName    Name of the modifier key to sticky or hold (e.g., "Ctrl").
  * @var {string} triggerKey    Scan code of the key that called the function. Important: The key the functions is mapped to must be defined using its scan code (e.g., "sc020"). 
  */
-StickyKey(stickyTimeout := 450, keyName := "") {
+StickyKey(stickyTimeout := 0, keyName := "") {
 
     ;; Extract the scan code from the key that called the function.
     RegExMatch(A_ThisHotkey, "i)sc[0-9A-F]+|.", &match)

--- a/Windows/AutoHotkey/Layers/Lib/sticky-key.ahk
+++ b/Windows/AutoHotkey/Layers/Lib/sticky-key.ahk
@@ -18,7 +18,7 @@
 StickyKey(stickyTimeout := 0, keyName := "") {
 
     ;; Extract the scan code from the key that called the function.
-    RegExMatch(A_ThisHotkey, "sc\d+", &match)
+    RegExMatch(A_ThisHotkey, "i)sc\d+", &match)
     triggerKey := match[0]
 
     Send "{Blind}{" keyName " Down}"

--- a/Windows/AutoHotkey/Layers/Lib/sticky-key.ahk
+++ b/Windows/AutoHotkey/Layers/Lib/sticky-key.ahk
@@ -13,7 +13,7 @@
 /**
  * @param {int} stickyTimeout    Sticky-time after a tap-and-release.
  * @param {string} keyName    Name of the modifier key to sticky or hold (e.g., "Ctrl").
- * @var {string} triggerKey    Scan code of the key that called the function. Important: The key the functions is mapped to must be defined using its scan code (e.g., "sc020"). 
+ * @var {string} triggerKey    Scan code of the key that called the function. Important: The key the functions is mapped to must be defined using its scan code (e.g., "sc020").
  */
 StickyKey(stickyTimeout := 0, keyName := "") {
 

--- a/Windows/AutoHotkey/Layers/extend.ahk
+++ b/Windows/AutoHotkey/Layers/extend.ahk
@@ -1,7 +1,7 @@
 /*
  * File        : extend.ahk
  * Description : AutoHotkey keyboard layer configuration file (Keeb Utils)
- * Copyright   : (c) 2024-2025, Gergely Szabo
+ * Copyright   : (c) 2024-2026, Gergely Szabo
  * License     : MIT
  *
  * AutoHotkey adds an "Extend" layer by defining new key shortcuts using the

--- a/Windows/AutoHotkey/Layers/extend.ahk
+++ b/Windows/AutoHotkey/Layers/extend.ahk
@@ -44,19 +44,19 @@ CapsLock::F24
 SetCapsLockState "AlwaysOff"
 
 ;; Function Row
-F24 & sc001::Return                                 ;; Esc
-F24 & sc03B::Return                                 ;; F1
-F24 & sc03C::Return                                 ;; F2
-F24 & sc03D::Return                                 ;; F3
-F24 & sc03E::Return                                 ;; F4
-F24 & sc03F::Return                                 ;; F5
-F24 & sc040::Return                                 ;; F6
-F24 & sc041::Return                                 ;; F7
-F24 & sc042::Return                                 ;; F8
-F24 & sc043::Return                                 ;; F9
-F24 & sc044::Return                                 ;; F10
-F24 & sc057::Return                                 ;; F11
-F24 & sc058::Return                                 ;; F12
+F24 & sc001::return                                 ;; Esc
+F24 & sc03B::return                                 ;; F1
+F24 & sc03C::return                                 ;; F2
+F24 & sc03D::return                                 ;; F3
+F24 & sc03E::return                                 ;; F4
+F24 & sc03F::return                                 ;; F5
+F24 & sc040::return                                 ;; F6
+F24 & sc041::return                                 ;; F7
+F24 & sc042::return                                 ;; F8
+F24 & sc043::return                                 ;; F9
+F24 & sc044::return                                 ;; F10
+F24 & sc057::return                                 ;; F11
+F24 & sc058::return                                 ;; F12
 
 ;; Numeric Row
 F24 & sc029::Send "{Blind}{Escape}"                 ;; QWERTY `~
@@ -86,7 +86,7 @@ F24 & sc018::Send "{Bind}{End}"                     ;; QWERTY oO
 F24 & sc019::PrintScreen                            ;; QWERTY pP
 F24 & sc01A::NumLock                                ;; QWERTY [{
 F24 & sc01B::ScrollLock                             ;; QWERTY ]}
-F24 & sc02B::Return                                 ;; QWERTY \|
+F24 & sc02B::return                                 ;; QWERTY \|
 
 ;; Home Row
 F24 & sc01E::Send "{Blind}{LWin Down}"              ;; QWERTY aA

--- a/Windows/AutoHotkey/Layers/symbols.ahk
+++ b/Windows/AutoHotkey/Layers/symbols.ahk
@@ -1,7 +1,7 @@
 /*
  * File        : symbols.ahk
  * Description : AutoHotkey keyboard layer configuration file (Keeb Utils)
- * Copyright   : (c) 2024-2025, Gergely Szabo
+ * Copyright   : (c) 2024-2026, Gergely Szabo
  * License     : MIT
  *
  * AutoHotkey adds a "Symbols" layer by defining new key shortcuts using the
@@ -46,7 +46,7 @@ F23::
     ;; - On Tap: Normal Alt key behavior.
     ;; - On Hold: Hold the F23 virtual key to activate the layer.
     ;;
-    ;; KeyWait() monitors the physical state of Left Alt key using
+    ;; 'KeyWait()' monitors the physical state of Left Alt key using
     ;; its scan code (sc038).
 
     ;; On Tap

--- a/Windows/AutoHotkey/Layers/symbols.ahk
+++ b/Windows/AutoHotkey/Layers/symbols.ahk
@@ -40,24 +40,15 @@
 LAlt::F23
 #InputLevel 0
 
+;; Monitor the physical state of the Left Key using its scan code (sc038).
 F23::
 {
-    ;; Implement Tap-Hold Behavior:
-    ;; - On Tap: Normal Alt key behavior.
-    ;; - On Hold: Hold the F23 virtual key to activate the layer.
-    ;;
-    ;; 'KeyWait()' monitors the physical state of Left Alt key using
-    ;; its scan code (sc038).
-
-    ;; On Tap
     Send "{LAlt Down}"
 
-    ;; On Hold
     if !KeyWait("sc038") {
         Send "{F23}"
     }
 
-    ;; On Release
     KeyWait "sc038"
     Send "{Alt Up}"
 }

--- a/Windows/AutoHotkey/Layers/symbols.ahk
+++ b/Windows/AutoHotkey/Layers/symbols.ahk
@@ -63,34 +63,34 @@ F23::
 }
 
 ;; Function Row
-F23 & sc001::Return                         ;; Esc
-F23 & sc03B::Return                         ;; F1
-F23 & sc03C::Return                         ;; F2
-F23 & sc03D::Return                         ;; F3
-F23 & sc03E::Return                         ;; F4
-F23 & sc03F::Return                         ;; F5
-F23 & sc040::Return                         ;; F6
-F23 & sc041::Return                         ;; F7
-F23 & sc042::Return                         ;; F8
-F23 & sc043::Return                         ;; F9
-F23 & sc044::Return                         ;; F10
-F23 & sc057::Return                         ;; F11
-F23 & sc058::Return                         ;; F12
+F23 & sc001::return                         ;; Esc
+F23 & sc03B::return                         ;; F1
+F23 & sc03C::return                         ;; F2
+F23 & sc03D::return                         ;; F3
+F23 & sc03E::return                         ;; F4
+F23 & sc03F::return                         ;; F5
+F23 & sc040::return                         ;; F6
+F23 & sc041::return                         ;; F7
+F23 & sc042::return                         ;; F8
+F23 & sc043::return                         ;; F9
+F23 & sc044::return                         ;; F10
+F23 & sc057::return                         ;; F11
+F23 & sc058::return                         ;; F12
 
 ;; Numeric Row
-F23 & sc029::Return                         ;; QWERTY `~
-F23 & sc002::Return                         ;; QWERTY 1!
-F23 & sc003::Return                         ;; QWERTY 2@
-F23 & sc004::Return                         ;; QWERTY 3#
-F23 & sc005::Return                         ;; QWERTY 4$
-F23 & sc006::Return                         ;; QWERTY 5%
-F23 & sc007::Return                         ;; QWERTY 6^
-F23 & sc008::Return                         ;; QWERTY 7&
-F23 & sc009::Return                         ;; QWERTY 8*
-F23 & sc00A::Return                         ;; QWERTY 9(
-F23 & sc00B::Return                         ;; QWERTY 0)
-F23 & sc00C::Return                         ;; QWERTY -_
-F23 & sc00D::Return                         ;; QWERTY =+
+F23 & sc029::return                         ;; QWERTY `~
+F23 & sc002::return                         ;; QWERTY 1!
+F23 & sc003::return                         ;; QWERTY 2@
+F23 & sc004::return                         ;; QWERTY 3#
+F23 & sc005::return                         ;; QWERTY 4$
+F23 & sc006::return                         ;; QWERTY 5%
+F23 & sc007::return                         ;; QWERTY 6^
+F23 & sc008::return                         ;; QWERTY 7&
+F23 & sc009::return                         ;; QWERTY 8*
+F23 & sc00A::return                         ;; QWERTY 9(
+F23 & sc00B::return                         ;; QWERTY 0)
+F23 & sc00C::return                         ;; QWERTY -_
+F23 & sc00D::return                         ;; QWERTY =+
 
 ;; Top Row
 F23 & sc010::Send "{Raw}!"                  ;; QWERTY qQ

--- a/Windows/AutoHotkey/Modules/keeb-utils-icon.ahk
+++ b/Windows/AutoHotkey/Modules/keeb-utils-icon.ahk
@@ -4,13 +4,11 @@
  * Copyright   : (c) 2024-2025, Gergely Szabo
  * License     : MIT
  *
- * Usage:
- * The script file must be loaded when AutoHotkey starts. UpdateIcon() can be
- * called from other scripts to update the tray icon and tooltip based on the
- * current state of AutoHotkey.
+ * This function changes the AutoHotkey tray icon and text on mouse hover
+ * based on the application's state.
  */
 
-;; Load the default icon and tooltip.
+;; Set the default icon and tooltip.
 TraySetIcon("Icons\active.ico",, false)
 A_IconTip := "Keeb Utils is active"
 

--- a/Windows/AutoHotkey/Modules/keeb-utils-icon.ahk
+++ b/Windows/AutoHotkey/Modules/keeb-utils-icon.ahk
@@ -1,7 +1,7 @@
 /*
  * File        : keeb-utils-icon.ahk
  * Description : AutoHotkey function to update the tray icon (Keeb Utils)
- * Copyright   : (c) 2024-2025, Gergely Szabo
+ * Copyright   : (c) 2024-2026, Gergely Szabo
  * License     : MIT
  *
  * This function changes the AutoHotkey tray icon and text on mouse hover

--- a/Windows/AutoHotkey/Modules/keeb-utils-menu.ahk
+++ b/Windows/AutoHotkey/Modules/keeb-utils-menu.ahk
@@ -4,17 +4,13 @@
  * Copyright   : (c) 2024-2025, Gergely Szabo
  * License     : MIT
  *
- * Usage:
- * The script file must be loaded when AutoHotkey starts. The custom
- * menu is accessible by right clicking the tray icon.
+ * This script creates a minimalist tray icon menu for AutoHotkey with custom
+ * options.
  */
 
 #Include keeb-utils-icon.ahk
 
-;;;
-;;; MENU ITEMS
-;;;
-
+;; Menu Options
 Tray := A_TrayMenu                  ;; for convenience
 Tray.Delete()                       ;; delete the standard menu times
 Tray.Add("Active", ChangeStatus)
@@ -31,16 +27,11 @@ Tray.Add("")
 Tray.Add("Help", OpenHelp)
 Tray.Add("Exit", CloseAHK)
 
-;;;
-;;; MENU ITEMS CONFIGURATION
-;;;
-
 ChangeStatus(*)
 {
     static OldName := "", NewName := ""
 
-    ;; Use logic to toggle AutoHotkey between suspended and
-    ;; active states when the user clicks on the menu item.
+    ;; Switch between AutoHotkey states on item clicks.
     if NewName != "Disabled" {
         Suspend 1
         UpdateIcon()
@@ -62,7 +53,6 @@ ReloadScripts(*)
     Reload
 }
 
-;; Debug Submenu
 OpenHistory(*)
 {
     KeyHistory
@@ -70,32 +60,21 @@ OpenHistory(*)
 
 LineLogging(*)
 {
-    ;; Create a variable to store the function state:
-    ;; 0 = disabled
-    ;; 1 = enabled
     static LogLines := 0
 
-    ;; Use logic to toggle line logging when
-    ;; the user clicks on the menu item.
     if LogLines != 1 {
-        ;; Enable line logging and key history.
         ListLines 1
         KeyHistory 100
 
-        ;; Update the variable's value.
         LogLines := 1
     } else {
-        ;; Disable line logging and key history.
         ListLines 0
         KeyHistory 0
 
-        ;; Update the variable's value.
         LogLines := 0
     }
-    ;; Update the menu item's check mark on user click.
     DebugMenu.ToggleCheck("Line Logging")
 }
-;; End of Debug Submenu
 
 OpenHelp(*)
 {

--- a/Windows/AutoHotkey/Modules/keeb-utils-menu.ahk
+++ b/Windows/AutoHotkey/Modules/keeb-utils-menu.ahk
@@ -1,7 +1,7 @@
 /*
  * File        : keeb-utils-menu.ahk
  * Description : Minimalist AutoHotkey tray icon menu (Keeb Utils)
- * Copyright   : (c) 2024-2025, Gergely Szabo
+ * Copyright   : (c) 2024-2026, Gergely Szabo
  * License     : MIT
  *
  * This script creates a minimalist tray icon menu for AutoHotkey with custom

--- a/Windows/AutoHotkey/Modules/keeb-utils-toggle.ahk
+++ b/Windows/AutoHotkey/Modules/keeb-utils-toggle.ahk
@@ -1,21 +1,12 @@
 /*
  * File        : keeb-utils-toggle.ahk
  * Description : AutoHotkey state toggle (Keeb Utils)
- * Copyright   : (c) 2024-2025, Gergely Szabo
+ * Copyright   : (c) 2024-2026, Gergely Szabo
  * License     : MIT
  *
- * The hotkey disables all scripts with a single key combination,
- * eliminating the need to right-click AutoHotkey's tray icon
- * then selecting "Suspend Hotkeys".
- *
- * #SuspendExempt allows AutoHotkey to recognize the key combination
- * even when it's in suspended state. UpdateIcon() changes the
- * tray icon and tooltip to reflect AutoHotkey's status.
- *
- * Usage:
- * The script file must be loaded when AutoHotkey starts.
- * Suspending or activating AutoHotkey is achieved by pressing
- * Scroll Lock+Q.
+ * This script creates a hotkey to toggle between AutoHotkey's suspended and
+ * active states using 'Scroll Lock+Q'. AutoHotkey listens for the hotkey even
+ * when it's suspended.
  */
 
 #Include keeb-utils-icon.ahk
@@ -24,13 +15,9 @@
 SetScrollLockState "AlwaysOff"
 
 #SuspendExempt
-ScrollLock & sc010::    ;; Scroll Lock+Q
+ScrollLock & sc010::
 {
-    ;; Toggle between suspended and active states:
-    ;; 0 = activate
-    ;; 1 = suspend
-    ;; -1 = switch to opposite state
-    Suspend -1
+    Suspend -1      ;; -1 = switch to the opposite state
     UpdateIcon()
 }
 #SuspendExempt False

--- a/Windows/AutoHotkey/README.md
+++ b/Windows/AutoHotkey/README.md
@@ -16,24 +16,21 @@
 > [!NOTE]
 > An alternative solution to AutoHotkey on Windows is [KMonad](/Linux/KMonad/README.md#windows).
 
-## Installation & Startup
+## Requirements
 
-> [!IMPORTANT]
-> **This repository does not package or distribute AutoHotkey binaries required to run the Keeb Utils configuration files. It is your responsibility to install the required software version.**
+- **AutoHotkey v2.0:** Ensure you have the latest version of AutoHotkey installed. The scripts may run on AutoHotkey 1.0, but they are likely to behave incorrectly.
+- **Windows 7.0+:** Windows 10 and 11 are guaranteed to be compatible. These scripts are tested on modern Windows environments.
 
-1. Install AutoHotkey from [www.AutoHotkey.com](https://www.autohotkey.com) (or use the portable version).
+## Installation
 
-2. Donwload the contents of this repository to your computer.
+1. **Download the scripts:** Clone or download this repository to your computer.
+2. **Run the main script:** Navigate<b>*</b> to `keeb-utils-main\Windows\AutoHotkey` and double click `keeb-utils.ahk`
 
-3. Extract `keeb-utils-main.zip`.
+<b>*</b> If you downloaded the repository, extract the archive first.
 
-4. Navigate to `keeb-utils-main\Windows\AutoHotkey` and double-click `keeb-utils.ahk`.
+## Usage
 
-> [!CAUTION]
-> **The Keeb Utils configuration files support AutoHotkey version 2.0. While running them under version 1.0 may be possible, you may experience problems or erratic behavior.**
-
-> [!TIP]
-> To quit AutoHotkey, use the tray icon or close the `AutoHotkey64.exe` process in Task Manager.
+The scripts run in the background. You can see the AutoHotkey icon (replaced by the project's) in your system tray when AutoHotkey is running. If you want to quit AutoHotkey, right click the system tray icon and select *Exit*.
 
 > [!NOTE]
-> AutoHotkey must be reloaded everytime you make changes to a configuration file. You can use the tray icon.
+> To use Keeb Utils in all windows, you must run AutoHotkey as an Administrator. Otherwise, the script cannot control applications that have elevated privileges.

--- a/Windows/AutoHotkey/README.md
+++ b/Windows/AutoHotkey/README.md
@@ -18,13 +18,13 @@
 
 ## Requirements
 
-- **AutoHotkey v2.0:** Ensure you have the latest version of AutoHotkey installed. The scripts may run on AutoHotkey 1.0, but they are likely to behave incorrectly.
-- **Windows 7.0+:** Windows 10 and 11 are guaranteed to be compatible. These scripts are tested on modern Windows environments.
+- **AutoHotkey v2.0**: Ensure you have the latest version of AutoHotkey installed. The scripts may run on AutoHotkey 1.0, but they are likely to behave incorrectly.
+- **Windows 7.0+**: Windows 10 and 11 are guaranteed to be compatible. These scripts are tested on modern Windows environments.
 
 ## Installation
 
-1. **Download the scripts:** Clone or download this repository to your computer.
-2. **Run the main script:** Navigate<b>*</b> to `keeb-utils-main\Windows\AutoHotkey` and double click `keeb-utils.ahk`
+1. **Download the scripts**: Clone or download this repository to your computer.
+2. **Run the main script**: Navigate<b>*</b> to `keeb-utils-main\Windows\AutoHotkey` and double click `keeb-utils.ahk`
 
 <b>*</b> If you downloaded the repository, extract the archive first.
 

--- a/Windows/AutoHotkey/keeb-utils.ahk
+++ b/Windows/AutoHotkey/keeb-utils.ahk
@@ -8,9 +8,9 @@
  * loaded by this file run with the settings defined here.
  */
 
-;;;
-;;; AUTOHOTKEY GENERAL SETTINGS
-;;;
+;;
+;; AutoHotkey General Settings
+;;
 
 ;; Define the AutoHotkey version required to run this script.
 ;; https://www.autohotkey.com/docs/v2/lib/_Requires.htm
@@ -54,9 +54,9 @@ ProcessSetPriority "High"
 ;; (default True)
 Persistent True
 
-;;;
-;;; INPUT SETTINGS
-;;;
+;;
+;; Input Settings
+;;
 
 ;; Set the interval in seconds before a warning dialog is triggered
 ;; by consecutive hotkey execution; i.e. key spamming.
@@ -83,9 +83,9 @@ SendMode "Event"
 ;; (default 10)
 SetKeyDelay -1, -1
 
-;;;
-;;; DEBUGGING SETTINGS
-;;;
+;;
+;; Debugging Settings
+;;
 
 ;; Enables or disables line logging or displays the script
 ;; lines most recently executed.
@@ -99,10 +99,9 @@ ListLines 0
 ;; (default 40)
 KeyHistory 0
 
-;;;
-;;; KEEB UTILS
-;;;
-
+;;
+;; Keeb Utils Configuration
+;;
 ;; Scripts on commented lines (starting with ;;) are not loaded,
 ;; therefore remain disabled.
 


### PR DESCRIPTION
### Change

- Change code comments voice to active voice.
- Change code comments to [Simplified Technical English](https://en.wikipedia.org/wiki/Simplified_Technical_English) convention.
- Update license date in file headers where applicable.
- Change the `Return` keyword to `return` (lowercase) where we don't mean the <kbd>Enter</kbd> key.
- Update the regular expression routine in `multi-sticky.ahk` and `sticky-key.ahk` with the case-insensitive option.
- Remove uppercase code section headers (“Stop shouting!”).
- Update the `README.md`'s to better match the code comments and apply formatting changes for better readability.

### Remove

- Remove comments duplicating the code.
- Trailing whitespaces.