### PR TITLE
Autohotkey style guide

### DIFF
--- a/Docs/CONTRIBUTING.md
+++ b/Docs/CONTRIBUTING.md
@@ -6,3 +6,7 @@ https://lisp-lang.org/style-guide
 
 Exception for single line comments: KMonad interprets ";" as the QWERTY key <kbd>;:</kbd> (next to <kbd>L</kbd>),
 use two semicolons instead (;;).
+
+## AutoHotkey Style Guide
+
+There aren't famous style guides or standards agreed upon by the AutoHotkey community, so stick to [K&R](https://en.wikipedia.org/wiki/Indentation_style#K&R), and max. 100 characters line length.

--- a/Windows/AutoHotkey/Modules/keeb-utils-icon.ahk
+++ b/Windows/AutoHotkey/Modules/keeb-utils-icon.ahk
@@ -12,7 +12,8 @@
 TraySetIcon("Icons\active.ico",, false)
 A_IconTip := "Keeb Utils is active"
 
-UpdateIcon() {
+UpdateIcon()
+{
     if A_IsSuspended = 1 {
         TraySetIcon("Icons\suspended.ico",, true)
         A_IconTip := "Keeb Utils is disabled"

--- a/Windows/AutoHotkey/Modules/keeb-utils-menu.ahk
+++ b/Windows/AutoHotkey/Modules/keeb-utils-menu.ahk
@@ -32,7 +32,8 @@ Tray.Add()
 Tray.Add("Help", OpenHelp)
 Tray.Add("Exit", CloseAHK)
 
-ChangeStatus(*) {
+ChangeStatus(*)
+{
     static oldName := "", newName := ""
 
     ;; Switch between AutoHotkey states on item clicks.
@@ -52,15 +53,18 @@ ChangeStatus(*) {
     Tray.Rename(oldName, newName)
 }
 
-ReloadScripts(*) {
+ReloadScripts(*)
+{
     Reload
 }
 
-OpenHistory(*) {
+OpenHistory(*)
+{
     KeyHistory
 }
 
-LineLogging(*) {
+LineLogging(*)
+{
     static logLines := 0
 
     if logLines != 1 {
@@ -77,7 +81,8 @@ LineLogging(*) {
     DebugMenu.ToggleCheck("Line Logging")
 }
 
-OpenHelp(*) {
+OpenHelp(*)
+{
     if DirExist("C:\Users\" . A_Username . "\AppData\Local\Programs\AutoHotkey") {
         Run 'hh.exe "C:\Users\' A_Username '\AppData\Local\Programs\AutoHotkey\v2\AutoHotkey.chm" href'
     } else {
@@ -85,11 +90,12 @@ OpenHelp(*) {
     }
 }
 
-CloseAHK(*) {
+CloseAHK(*)
+{
     ExitApp
 }
 
 ;; Set activating/suspending AutoHotkey as the default option
-;; when user double clicks the tray icon.
+;; when double clicking the tray icon.
 CurrentDefault := Tray.Default
 Tray.Default := "Active"

--- a/Windows/AutoHotkey/keeb-utils.ahk
+++ b/Windows/AutoHotkey/keeb-utils.ahk
@@ -1,16 +1,16 @@
 /*
  * File        : keeb-utils.ahk
- * Description : Entry-point to AutoHotkey implementation of Keeb Utils
+ * Description : Entry-point to the AutoHotkey implementation of Keeb Utils
  * Copyright   : (c) 2024-2025, Gergely Szabo
  * License     : MIT
  *
- * This file configures AutoHotkey and the behavior of scripts. All scripts
- * loaded by this file run with the settings defined here.
+ * This file configures AutoHotkey and the behavior of scripts. All scripts loaded by this
+ * file run with the settings defined here.
  */
 
-;;
+;; ================================================================================================
 ;; AutoHotkey General Settings
-;;
+;; ================================================================================================
 
 ;; Define the AutoHotkey version required to run this script.
 ;; https://www.autohotkey.com/docs/v2/lib/_Requires.htm
@@ -54,9 +54,9 @@ ProcessSetPriority "High"
 ;; (default True)
 Persistent True
 
-;;
+;; ================================================================================================
 ;; Input Settings
-;;
+;; ================================================================================================
 
 ;; Set the interval in seconds before a warning dialog is triggered
 ;; by consecutive hotkey execution; i.e. key spamming.
@@ -83,9 +83,9 @@ SendMode "Event"
 ;; (default 10)
 SetKeyDelay -1, -1
 
-;;
+;; ================================================================================================
 ;; Debug Settings
-;;
+;; ================================================================================================
 
 ;; Enables or disables line logging or displays the script
 ;; lines most recently executed.
@@ -99,9 +99,9 @@ ListLines 0
 ;; (default 40)
 KeyHistory 0
 
-;;
+;; ================================================================================================
 ;; Keeb Utils Configuration
-;;
+;; ================================================================================================
 
 ;; Keyboard Layouts
 ;; Keymaps defining the physical key arrangements and character


### PR DESCRIPTION
### Add

- AutoHotkey style guide definition – adopt a sensible approach since there are no community or company style guides.