### PR TITLE
update(ci): rely on shell prompts instead of code comments for easier workflow job vetting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,36 +8,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install AutoHotkey and Validate the Syntax
+      - name: Install AutoHotkey and validate the syntax
         shell: powershell
         run: |
-          # 1. Bootstrap Scoop
-          #
-          # We use a non-interactive install.
-          # If Scoop is already present, this verifies the shim setup.
+          Write-Host "Bootstrapping Scoop package manager..."
           iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
 
-          # 2. Define Absolute Paths
-          #
-          # Windows runners often fail to refresh '$env:PATH' mid-job.
-          # We bypass this by pointing directly to the known Scoop
-          # installation directory.
+          Write-Host "Setting up Scoop environment variables..."
           $scoopPath = "$env:USERPROFILE\scoop"
           $scoopBin  = "$scoopPath\apps\scoop\current\bin\scoop.ps1"
           $ahkExe    = "$scoopPath\apps\autohotkey\current\v2\AutoHotkey64.exe"
 
-          # 3. Provision Dependencies
-          #
-          # We call the scoop.ps1 script directly to ensure the command works
-          # regardless of the PATH state.
-          Write-Host "Installing/Verifying AutoHotkey via Scoop..."
+          Write-Host "Installing AutoHotkey via Scoop..."
           & $scoopBin bucket add extras
           & $scoopBin install extras/autohotkey
 
-          # 4. Syntax Verification
-          #
-          # Loop through all .ahk files and use the '/i' flag to check
-          # for syntax errors.
+          Write-Host "Validating AutoHotkey syntax..."
           Get-ChildItem -Recurse -Filter "*.ahk" | ForEach-Object {
             Write-Host "Checking syntax: $($_.FullName)"
             & $ahkExe /i "$($_.FullName)"
@@ -49,13 +35,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Download the KMonad Binary
+      - name: Install KMonad
         run: |
-          # Fetch the static KMonad binary.
           curl -L "https://github.com/kmonad/kmonad/releases/download/0.4.4/kmonad" -o kmonad
           chmod +x kmonad
 
-      - name: KMonad Configuration Validation
+      - name: Validate the KMonad syntax
         run: |
-          # Validate the configuration with the '-d' flag.
           find . -name "*.kbd" -exec ./kmonad -d {} +


### PR DESCRIPTION
### Change

- Switch from comments in the YAML code to PowerShell's `Write-Host` command.