### PR TITLE
KMonad 0.4.5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install KMonad
         run: |
-          curl -L "https://github.com/kmonad/kmonad/releases/download/0.4.4/kmonad" -o kmonad
+          curl -L "https://github.com/kmonad/kmonad/releases/download/0.4.5/kmonad" -o kmonad
           chmod +x kmonad
 
       - name: Validate the KMonad syntax

--- a/Docs/CONTRIBUTING.md
+++ b/Docs/CONTRIBUTING.md
@@ -8,20 +8,20 @@ This project follows the [**Google Developer Documentation Style Guide**](https:
 
 ## KMonad (Lisp Style)
 
-* Follow the [Lisp Style Guide](https://lisp-lang.org/style-guide).
-* **Exception**: Because KMonad interprets a single `;` as the `<kbd>;:</kbd>` key, use double semicolons (`;;`) for all comments.
+- Follow the [Lisp Style Guide](https://lisp-lang.org/style-guide).
+- **Exception**: Because KMonad interprets a single `;` as the `<kbd>;:</kbd>` key, use double semicolons (`;;`) for all comments.
 
 ## AutoHotkey
 
-* Use the **K&R indentation style**.
-* Limit lines to a maximum of **100 characters**.
+- Use the **K&R indentation style**.
+- Limit lines to a maximum of **100 characters**.
 
 ## Commenting (All Languages)
 
 Based on the [_Rust Style Guide_](https://doc.rust-lang.org/beta/style-guide/index.html), comments should be treated as professional documentation:
-* **Sentences**: Use complete sentences. Start with a capital letter and end with a period.
-* **Inline Notes**: Brief inline comments may be written as notes without punctuation.
-* **Line Length**: Comments on their own lines should not exceed **80 characters** or the current indentation limit, whichever is smaller.
+- **Sentences**: Use complete sentences. Start with a capital letter and end with a period.
+- **Inline Notes**: Brief inline comments may be written as notes without punctuation.
+- **Line Length**: Comments on their own lines should not exceed **80 characters** or the current indentation limit, whichever is smaller.
 
 ## Commit Message Guidelines
 
@@ -53,8 +53,8 @@ To maintain a stable production environment, this repository follows a strict br
 ### Direct Commits to Main
 
 Direct commits to the `main` branch are **restricted to non-functional changes** only. This includes:
-* **Documentation**: Fixing typos, updating `README.md`, or clarifying instructions.
-* **Metadata**: Small adjustments to `.gitignore` or project metadata.
+- **Documentation**: Fixing typos, updating `README.md`, or clarifying instructions.
+- **Metadata**: Small adjustments to `.gitignore` or project metadata.
 
 ### Feature & Refactor Branches
 
@@ -65,5 +65,5 @@ All functional changes (scripts, CI/CD workflow updates, or configuration logic)
 
 ## Documentation Tone
 
-* **Use the Imperative**: Write instructions as commands (e.g., “Install the driver” instead of “The driver should be installed”).
-* **Be Direct**: Avoid “I” or “we.” Focus on the action the user or the software performs.
+- **Use the Imperative**: Write instructions as commands (e.g., “Install the driver” instead of “The driver should be installed”).
+- **Be Direct**: Avoid “I” or “we.” Focus on the action the user or the software performs.

--- a/Linux/KMonad/keeb-utils.kbd
+++ b/Linux/KMonad/keeb-utils.kbd
@@ -190,13 +190,13 @@
 
   ;; Multi-Sticky Keys
   ;;
-  ;; The aliases below resolve the limitation where separate `sticky-key'
-  ;; definitions (like one for <Ctrl> and one for <Shift>) do not combine
-  ;; (<Ctrl>+<Shift>). Using `multi-tap' creates a composite sticky key
-  ;; that allows for combinations like <Ctrl>+<Shift>+<S>.
+  ;; These aliases resolve the limitation where separate `sticky-key'
+  ;; definitions, `sticky-key 100 lctl' and `sticky-key 100 lsft' do not
+  ;; combine to <Ctrl>+<Shift> when pressed together. Using `multi-tap'
+  ;; creates a composite sticky key allowing for triple-key combinations
+  ;; (two modifiers + a regular key) such as <Ctrl>+<Shift>+<S> to work.
   ;;
-  ;; Note: This requires KMonad to be compiled from source with the patch
-  ;; from https://github.com/kmonad/kmonad/discussions/1013 (commit 21744cc).
+  ;; See the related discussion in https://github.com/kmonad/kmonad/discussions/1013.
   ams (multi-tap 120
         (sticky-key 280 lalt)
         (sticky-key 280 A-lsft))


### PR DESCRIPTION
### Change

- Update the KMonad binary for configuration syntax check to 0.4.5 in `lint.yml` (commit cf9b0e703b5ef17a2b1f350b5331ea7d127e9c1b).
- Improve the KMonad code comments for multi-sticky key functionality in `keeb-utils.kbd` (commit 5c308e89e88726c8e08fefbeff8e244429557df5).
- Improve documentation formatting consistency in `CONTRIBUTING.md` (commit d088bd47cbb29161f6e115ecd9eaa80f49dadce1).